### PR TITLE
Restore hapi-fhir-jpaserver-7 configuration to talk to postgres::hapi_r4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,24 @@ services:
     restart: on-failure
     ports:
       - "8080:8080"
-  hapi-fhir-postgres:
-    image: postgres:13-alpine
-    container_name: hapi-fhir-postgres
-    restart: always
+    network_mode: "host"
     environment:
-      POSTGRES_DB: "hapi"
-      POSTGRES_USER: "admin"
-      POSTGRES_PASSWORD: "admin"
-    volumes:
-      - hapi-fhir-postgres:/var/lib/postgresql/data
-volumes:
-  hapi-fhir-postgres:
+      SPRING_DATASOURCE_URL: "jdbc:postgresql://127.0.0.1:5432/hapi_r4"
+      SPRING_DATASOURCE_USERNAME: "tradmin"
+      SPRING_DATASOURCE_PASSWORD: "tradmin"
+      SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
+      SPRING_JPA_DATABASE_PLATFORM: "org.hibernate.dialect.PostgreSQLDialect"
+      SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT: "ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect"
+
+#   hapi-fhir-postgres:
+#     image: postgres:13-alpine
+#     container_name: hapi-fhir-postgres
+#     restart: always
+#     environment:
+#       POSTGRES_DB: "hapi"
+#       POSTGRES_USER: "admin"
+#       POSTGRES_PASSWORD: "admin"
+#     volumes:
+#       - hapi-fhir-postgres:/var/lib/postgresql/data
+# volumes:
+#   hapi-fhir-postgres:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,10 +19,14 @@ spring:
     fail-on-missing-locations: false
   datasource:
     #url: 'jdbc:h2:file:./target/database/h2'
-    url: jdbc:h2:mem:test_mem
-    username: sa
-    password: null
-    driverClassName: org.h2.Driver
+    #url: jdbc:h2:mem:test_mem
+    url: jdbc:postgresql://127.0.0.1:5432/hapi_r4
+    #username: sa
+    #password: null
+    username: tradmin
+    password: tradmin
+    #driverClassName: org.h2.Driver
+    driverClassName: org.postgresql.Driver
     max-active: 15
 
     # database connection pool size
@@ -35,8 +39,9 @@ spring:
 
       #Hibernate dialect is automatically detected except Postgres and H2.
       #If using H2, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
-      #If using postgres, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
-      hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
+      #If using postgres, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect
+      hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
+      #hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
   #      hibernate.hbm2ddl.auto: update
   #      hibernate.jdbc.batch_size: 20
   #      hibernate.cache.use_query_cache: false


### PR DESCRIPTION
The FHIR service at :8080/fhir was not able to connect to postgres::hapi_r4 which broke RISA on the QA environment.  SLV would appear if cached, but no questions could be answered because trais would try to map the patient id to a fhir id and fail to find it. 